### PR TITLE
Don't error if device switched off

### DIFF
--- a/lifx/device.py
+++ b/lifx/device.py
@@ -52,6 +52,7 @@ class Device(object):
 
     def _packethandler(self, host, port, packet):
         self._seen()
+	self._host = host
 
         # If it was a service packet
         if packet.protocol_header.pkt_type == protocol.TYPE_STATESERVICE:

--- a/lifx/device.py
+++ b/lifx/device.py
@@ -27,6 +27,7 @@ class Device(object):
         # Our Device
         self._device_id = device_id
         self._host = host
+        self._label = None
 
         # Services
         self._services = {}
@@ -257,13 +258,16 @@ class Device(object):
         """
         The label for the device, setting this will change the label on the device.
         """
-        response = self._block_for_response(pkt_type=protocol.TYPE_GETLABEL)
-        return protocol.bytes_to_label(response.label)
+        if self._label is None:
+            response = self._block_for_response(pkt_type=protocol.TYPE_GETLABEL)
+            self._label = protocol.bytes_to_label(response.label)
+        return self._label
 
     @label.setter
     def label(self, label):
         newlabel = bytearray(label.encode('utf-8')[0:protocol.LABEL_MAXLEN])
 
+        self._label = newlabel
         return self._block_for_ack(newlabel, pkt_type=protocol.TYPE_SETLABEL)
 
     def fade_power(self, power, duration=DEFAULT_DURATION):


### PR DESCRIPTION
Previously get_device or the related functions would retrieve a list of
devices that it contacted in the last x seconds. Then we would contact
each light in turn to try and apply some sort of filtering.

This would error out if the light had been switched off.

This patch attempts to contact each light and skips it if it cannot be
contacted.

Closes #6

Note: I haven't tested this latest version just yet. The previous version, which was similar worked fine. Will do that ASAP.
